### PR TITLE
make some changes for conflict of 'message_id'

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
             $timeout = $this->timeout;
         }
 
-        $event = new Request($name, $args);
+	$event = new Request($name, $args, uniqid(posix_getpid()));
         $this->context->hookBeforeSendRequest($event, $this);
         $this->socket->sendMulti($event->serialize());
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
             $timeout = $this->timeout;
         }
 
-	$event = new Request($name, $args, uniqid(posix_getpid()));
+        $event = new Request($name, $args, uniqid(posix_getpid()));
         $this->context->hookBeforeSendRequest($event, $this);
         $this->socket->sendMulti($event->serialize());
 


### PR DESCRIPTION
What I'm doing:

In a parallel enviroment (100 zerorpc progress).  we may got some error as follow:
```
File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run File "/Users/barry.bao/Workspace/juwai-rpc/.virtualenv/lib/python2.7/site-packages/zerorpc/core.py", line 162, in _async_task bufchan.close() File "/Users/barry.bao/Workspace/juwai-rpc/.virtualenv/lib/python2.7/site-packages/zerorpc/channel.py", line 203, in close self._channel.close() File "/Users/barry.bao/Workspace/juwai-rpc/.virtualenv/lib/python2.7/site-packages/zerorpc/heartbeat.py", line 70, in close self._channel.close() File "/Users/barry.bao/Workspace/juwai-rpc/.virtualenv/lib/python2.7/site-packages/zerorpc/channel.py", line 139, in close del self._multiplexer._active_channels[self._channel_id] KeyError: '5c77beb78c243' 2019-02-28T10:58:00Z >()> failed with KeyError
```

Because the zeromq server got some conflicts of 'message_id' which generated by client and the function uniqid() in base on system time.

uniqid() manual:
http://php.net/manual/en/function.uniqid.php
```
Warning
This function tries to create unique identifier, but it does not guarantee 100% uniqueness of return value.
```

So a prefix of progress id is necessary.

How to test:

activate 10 php processes and request one rpc method in a loop. and observe the server's log.